### PR TITLE
Fix COT explanation to be decoded before the score

### DIFF
--- a/verifiers/gemini_verifier.py
+++ b/verifiers/gemini_verifier.py
@@ -17,8 +17,8 @@ from utils import load_verifier_prompt, convert_to_bytes
 
 
 class Score(typing.TypedDict):
-    score: float
     explanation: str
+    score: float
 
 
 class Grading(typing.TypedDict):

--- a/verifiers/qwen_verifier.py
+++ b/verifiers/qwen_verifier.py
@@ -56,8 +56,8 @@ DEVICE_MAP = {
 
 
 class Score(BaseModel):
-    score: float
     explanation: str
+    score: float
 
 
 class Grading(BaseModel):


### PR DESCRIPTION
@sayakpaul Really cool project. Just wanted to point out one minor issue.

Currently the score is placed before the explanation in the schema for each grader. As such, the LLM will generate the score before the explanation during decoding. 

```python
class Score(typing.TypedDict):
    score: float
    explanation: str
```

What you instead want is the explanation before the score. Cause, we want the model to generate its rationale/chain-of-thought and then arrive at the score during decoding. That helps with better grading.

```python
class Score(typing.TypedDict):
    explanation: str
    score: float
```

If you generate the `score` before, the tokens for `rationale` are simply post-hoc explanation for the score. 

Karpathy actually discusses this as well in his latest video [here](https://youtu.be/7xTGNNLPyMI?t=6416) starting at timestamp `1:46:56`.

![image](https://github.com/user-attachments/assets/1d5a7117-516a-414d-a464-b6daf4c2dd6f)


Here is another [article](https://dylancastillo.co/posts/llm-pydantic-order-matters.html) from someone who did statistical analysis to prove that the order matters, in case you are interested to dig deeper.
