### PR TITLE
Added encoding and missing protobuf requirement

### DIFF
--- a/main.py
+++ b/main.py
@@ -175,7 +175,7 @@ def main():
 
     # Load prompts from file.
     if args.prompt is None:
-        with open("prompts_open_image_pref_v1.txt", "r") as f:
+        with open("prompts_open_image_pref_v1.txt", "r", encoding='utf-8' ) as f:
             prompts = [line.strip() for line in f.readlines() if line.strip()]
         if num_prompts != "all":
             prompts = prompts[:num_prompts]

--- a/main.py
+++ b/main.py
@@ -175,7 +175,7 @@ def main():
 
     # Load prompts from file.
     if args.prompt is None:
-        with open("prompts_open_image_pref_v1.txt", "r", encoding='utf-8' ) as f:
+        with open("prompts_open_image_pref_v1.txt", "r", encoding="utf-8") as f:
             prompts = [line.strip() for line in f.readlines() if line.strip()]
         if num_prompts != "all":
             prompts = prompts[:num_prompts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ git+https://github.com/huggingface/transformers.git@006d9249ec0270ff6c4d3840979d
 pydantic
 outlines
 accelerate
+protobuf
 sentencepiece


### PR DESCRIPTION
I was getting the following error for the encoding:
(venv) E:\stable\Bigfield77tt-scale-flux\tt-scale-flux>python main.py
E:\stable\Bigfield77tt-scale-flux\venv\lib\site-packages\transformers\utils\hub.py:127: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
Artifacts will be saved to: output\flux.1-dev\gemini\overall_score\20250218_000647
Traceback (most recent call last):
  File "E:\stable\Bigfield77tt-scale-flux\tt-scale-flux\main.py", line 230, in <module>
    main()
  File "E:\stable\Bigfield77tt-scale-flux\venv\lib\site-packages\torch\utils\_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "E:\stable\Bigfield77tt-scale-flux\tt-scale-flux\main.py", line 179, in main
    prompts = [line.strip() for line in f.readlines() if line.strip()]
  File "C:\Users\fgran\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 6404: character maps to <undefined>